### PR TITLE
fix: dev: change test script to only try and verify paths that exist

### DIFF
--- a/test-papers
+++ b/test-papers
@@ -97,6 +97,10 @@ class Verifier(object):
                 raise ValueError('REPORT NOT FOUND: {}'.format(report))
 
 for path in hid_dirs:
+    if not os.path.exists(path):
+        print('Skipping %s. Path does not exist.' % path)
+        continue
+    
     verify = Verifier(path)
 
     try:
@@ -107,6 +111,3 @@ for path in hid_dirs:
     except CalledProcessError, e:
         print('FAIL')
         raise
-
-
-    


### PR DESCRIPTION
This fixes the case where there are no submissions, and a path like paper*/* passed to test-papers is not expanded. @badi, if you think there is a better way to address this, or that we should always have at least one submission, let me know and I will add a dummy submission.