### PR TITLE
chg: dev: don't display error if no docx files to remove

### DIFF
--- a/setup
+++ b/setup
@@ -155,7 +155,7 @@ git-clone-directory() {
     find_dir_contents .         -print0 | xargs -0      rm -rf
     find_dir_contents "$TMPDIR" -print0 | xargs -0 -n 1 | while read path; do mv "$path" "$PWD"; done
 
-    rm *.docx
+    rm -f *.docx
 
 }
 


### PR DESCRIPTION
Just don't want students to think something is wrong when they see 

rm: cannot remove '*.docx': No such file or directory

at the end.